### PR TITLE
Return Flood Percentage Array instead of Map

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/ElevationData.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/ElevationData.scala
@@ -20,18 +20,18 @@ object ElevationData {
 
   private val wmLayoutScheme = ZoomedLayoutScheme(WebMercator, tileSize = 256)
 
-  // Polygon is in EPSG:4269
-  def apply(polygon: Polygon)(implicit sc: SparkContext): RasterRDD[SpatialKey] =
+  // MultiPolygon is in EPSG:4269
+  def apply(multiPolygon: MultiPolygon)(implicit sc: SparkContext): RasterRDD[SpatialKey] =
     HadoopLayerReader.spatial(path)
       .query(LayerId(dem10mLayer, 0))
-      .where(Intersects(polygon.envelope))
+      .where(Intersects(multiPolygon.envelope))
       .toRDD
 
-  /** Returns a tile if it intersects with this polygon (Web Mercator) */
-  def apply(zoom: Int, key: SpatialKey, polygon: Polygon)(implicit sc: SparkContext): Option[Tile] = {
+  /** Returns a tile if it intersects with this multiPolygon (Web Mercator) */
+  def apply(zoom: Int, key: SpatialKey, multiPolygon: MultiPolygon)(implicit sc: SparkContext): Option[Tile] = {
     val transform = MapKeyTransform(WebMercator, wmLayoutScheme.levelForZoom(zoom))
     val extent = transform(key)
-    if(extent.intersects(polygon)) {
+    if(extent.intersects(multiPolygon)) {
       Some(apply(zoom, key))
     } else {
       None

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -56,9 +56,9 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
       entity(as[minElevationArgs]) { (args) =>
         complete {
           future {
-            val polygon = args.polygon.toString().parseGeoJson[Polygon].reproject(LatLng, nativeCRS)
+            val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, nativeCRS)
             JsObject(
-              "minElevation" -> JsNumber(MinElevation(polygon))
+              "minElevation" -> JsNumber(MinElevation(multiPolygon))
             )
           }
         }
@@ -72,8 +72,8 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
       entity(as[floodPercentagesArgs]) { (args) =>
         complete {
           future {
-            val polygon = args.polygon.toString().parseGeoJson[Polygon].reproject(LatLng, nativeCRS)
-            FloodPercentages(polygon, args.floodLevels, args.minElevation)
+            val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, nativeCRS)
+            FloodPercentages(multiPolygon, args.floodLevels, args.minElevation)
           }
         }
       }
@@ -86,12 +86,12 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
           complete {
             future {
 
-              val polygon = args.polygon.toString().parseGeoJson[Polygon].reproject(LatLng, WebMercator)
+              val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, WebMercator)
               val key = SpatialKey(x, y)
 
-              ElevationData(zoom, key, polygon) match {
+              ElevationData(zoom, key, multiPolygon) match {
                 case Some(tile) =>
-                  val floodTile = FloodTile(tile, polygon, args.minElevation, args.floodLevel)
+                  val floodTile = FloodTile(tile, multiPolygon, args.minElevation, args.floodLevel)
 
                   // Paint the tile
 

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -94,8 +94,8 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
                   val floodTile = FloodTile(tile, multiPolygon, args.minElevation, args.floodLevel)
 
                   // Paint the tile
-
-                  floodTile.renderPng(ColorRamps.BlueToRed).bytes
+                  val justBlueRamp = ColorRamp.createWithRGBColors(0x0000FF).setAlpha(127)
+                  floodTile.renderPng(justBlueRamp).bytes
 
                 case None =>
                   Array[Byte]()

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -80,25 +80,27 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
     }
 
   def floodTilesRoute =
-    pathPrefix(IntNumber / IntNumber / IntNumber) { (zoom, x, y) =>
-      entity(as[floodTilesArgs]) { (args) =>
-        respondWithMediaType(MediaTypes.`image/png`) {
-          complete {
-            future {
+    rejectEmptyResponse {
+      pathPrefix(IntNumber / IntNumber / IntNumber) { (zoom, x, y) =>
+        entity(as[floodTilesArgs]) { (args) =>
+          respondWithMediaType(MediaTypes.`image/png`) {
+            complete {
+              future {
 
-              val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, WebMercator)
-              val key = SpatialKey(x, y)
+                val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, WebMercator)
+                val key = SpatialKey(x, y)
 
-              ElevationData(zoom, key, multiPolygon) match {
-                case Some(tile) =>
-                  val floodTile = FloodTile(tile, multiPolygon, args.minElevation, args.floodLevel)
+                ElevationData(zoom, key, multiPolygon) match {
+                  case Some(tile) =>
+                    val floodTile = FloodTile(tile, multiPolygon, args.minElevation, args.floodLevel)
 
-                  // Paint the tile
-                  val justBlueRamp = ColorRamp.createWithRGBColors(0x0000FF).setAlpha(127)
-                  floodTile.renderPng(justBlueRamp).bytes
+                    // Paint the tile
+                    val justBlueRamp = ColorRamp.createWithRGBColors(0x0000FF).setAlpha(127)
+                    floodTile.renderPng(justBlueRamp).bytes
 
-                case None =>
-                  Array[Byte]()
+                  case None =>
+                    Array[Byte]()
+                }
               }
             }
           }

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodPercentages.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodPercentages.scala
@@ -110,6 +110,7 @@ object FloodPercentages {
             if(z - minElevation < level) {
               // This pixel is flooded under this level
               floodedCounts(level) += 1
+              i += 1
             } else {
               // This pixel isn't flooded under this level,
               // also not flooded by any lower level, so break

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
@@ -13,13 +13,13 @@ object FloodTile {
   /** Takes a polygon, flood level, zoom level and tile coordinates.
     * Returns a tile with the flood levels of each cell.
     * 
-    * @param       polygon       Polygon in EPSG:4269
+    * @param       multiPolygon  MultiPolygon in EPSG:4269
     * @param       minElevation  Minimum elevation under this polygon
     * @param       floodLevel    Flood level to use for determining cell flooding
     * 
     * @return      Tile with flood level of each flooded cell, NoData if the cell is not flooded.
     */
-  def apply(tile: Tile, polygon: Polygon, minElevation: Double, floodLevel: Double)(implicit sc: SparkContext): Tile =
+  def apply(tile: Tile, multiPolygon: MultiPolygon, minElevation: Double, floodLevel: Double)(implicit sc: SparkContext): Tile =
     tile.mapDouble { z =>
       if(isData(z) && z - minElevation < floodLevel) {
         z - minElevation

--- a/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
@@ -3,9 +3,9 @@ package com.azavea.usaceflood.server
 import spray.httpx.SprayJsonSupport
 import spray.json._
 
-case class minElevationArgs (polygon: JsObject)
-case class floodPercentagesArgs (polygon: JsObject, minElevation: Double, floodLevels: Array[Double])
-case class floodTilesArgs (polygon: JsObject, minElevation: Double, floodLevel: Double)
+case class minElevationArgs (multiPolygon: JsObject)
+case class floodPercentagesArgs (multiPolygon: JsObject, minElevation: Double, floodLevels: Array[Double])
+case class floodTilesArgs (multiPolygon: JsObject, minElevation: Double, floodLevel: Double)
 
 object JsonProtocol extends SprayJsonSupport {
   import DefaultJsonProtocol._

--- a/server/src/main/scala/com/azavea/usaceflood/server/MinElevation.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/MinElevation.scala
@@ -9,10 +9,10 @@ object MinElevation {
   /** Takes a polygon and returns the elevation of the lowest cell
     * within the polygon.
     * 
-    * @param       polygon       Polygon in EPSG:4269
+    * @param       multiPolygon  MultiPolygon in EPSG:4269
     * 
     * @return      Elevation in meters
     */
-  def apply(polygon: Polygon)(implicit sc: SparkContext): Double =
-    ElevationData(polygon).zonalMin(polygon)
+  def apply(multiPolygon: MultiPolygon)(implicit sc: SparkContext): Double =
+    ElevationData(multiPolygon).zonalMin(multiPolygon)
 }


### PR DESCRIPTION
Note: Only the last commit is part of this PR, since it builds on top of #10.
## Overview

Since the values in the geoprocessing service are in Meters, but the front-end uses Feet, to return a map of the keys with odd looking decimal values in Meters would be confusing and unnecessary:

``` http
$ vagrant ssh -c 'http --body :8090/flood-percentages multiPolygon:=@multiPolygon.json minElevation:=293.0 floodLevels:=[0,0.1524,0.3048,0.4572,0.6096,0.762,0.9144,1.0668,1.2192,1.3716,1.524,1.6764,1.8288,1.9812,2.1336,2.286,2.4384,2.5908,2.7432,2.8956,3.048]'
{
    "0.0": 0.0, 
    "0.1524": 0.0, 
    "0.3048": 0.0, 
    "0.4572": 4.0870542556452434e-06, 
    "0.6096": 2.4522325533871462e-05, 
    "0.762": 8.174108511290487e-05, 
    "0.9144": 0.00015939511597016452, 
    "1.0668": 0.0005599264330233984, 
    "1.2192": 0.0018248697251456013, 
    "1.3716": 0.002799632165116992, 
    "1.524": 0.0034719525901706345, 
    "1.6764": 0.004291406968427506, 
    "1.8288": 0.008184326146929601, 
    "1.9812": 0.016949013998160827, 
    "2.1336": 0.03469091652191683, 
    "2.286": 0.06315724941248595, 
    "2.4384": 0.09177275978338613, 
    "2.5908": 0.11996526003882702, 
    "2.7432": 0.14448349851844283, 
    "2.8956": 0.1640993154184122, 
    "3.048": 0.1813998160825585
}
```

Instead, it is simpler for us to simply send back an array of percentages,which correspond to whatever flood levels were specified during input.
## Testing Instructions

Try with a set of known values previously used (for example in #10) and ensure you get the same output:

``` http
$ vagrant ssh -c 'http --body :8090/flood-percentages multiPolygon:=@multiPolygon.json minElevation:=293.0 floodLevels:=[0.0,0.5,1.0,1.5,2.0,2.5,3.0,3.5,4.0,4.5,5.0]'
[
    0.0, 
    1.0217635639113109e-05, 
    0.0002697455808725861, 
    0.0033595585981403904, 
    0.01845713701849392, 
    0.10324716460611015, 
    0.17560232962092573, 
    0.25526106059057935, 
    0.3358700316746705, 
    0.41125166036579136, 
    0.4814468172064984
]
```

Try with flood levels specified in feet converted to meters:

``` http
$ vagrant ssh -c 'http --body :8090/flood-percentages multiPolygon:=@multiPolygon.json minElevation:=293.0 floodLevels:=[0,0.1524,0.3048,0.4572,0.6096,0.762,0.9144,1.0668,1.2192,1.3716,1.524,1.6764,1.8288,1.9812,2.1336,2.286,2.4384,2.5908,2.7432,2.8956,3.048]'
[
    0.0, 
    0.0, 
    0.0, 
    4.0870542556452434e-06, 
    2.4522325533871462e-05, 
    8.174108511290487e-05, 
    0.00015939511597016452, 
    0.0005599264330233984, 
    0.0018248697251456013, 
    0.002799632165116992, 
    0.0034719525901706345, 
    0.004291406968427506, 
    0.008184326146929601, 
    0.016949013998160827, 
    0.03469091652191683, 
    0.06315724941248595, 
    0.09177275978338613, 
    0.11996526003882702, 
    0.14448349851844283, 
    0.1640993154184122, 
    0.1813998160825585
]
```

Connects https://github.com/azavea/usace-flood-model/issues/71
