### PR TITLE
Clip flood level output to multipolygon

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/ElevationData.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/ElevationData.scala
@@ -20,6 +20,11 @@ object ElevationData {
 
   private val wmLayoutScheme = ZoomedLayoutScheme(WebMercator, tileSize = 256)
 
+  def getExtent(zoom: Int, key: SpatialKey): Extent = {
+    val transform = MapKeyTransform(WebMercator, wmLayoutScheme.levelForZoom(zoom))
+    transform(key)
+  }
+
   // MultiPolygon is in EPSG:4269
   def apply(multiPolygon: MultiPolygon)(implicit sc: SparkContext): RasterRDD[SpatialKey] =
     HadoopLayerReader.spatial(path)
@@ -29,8 +34,7 @@ object ElevationData {
 
   /** Returns a tile if it intersects with this multiPolygon (Web Mercator) */
   def apply(zoom: Int, key: SpatialKey, multiPolygon: MultiPolygon)(implicit sc: SparkContext): Option[Tile] = {
-    val transform = MapKeyTransform(WebMercator, wmLayoutScheme.levelForZoom(zoom))
-    val extent = transform(key)
+    val extent = getExtent(zoom, key)
     if(extent.intersects(multiPolygon)) {
       Some(apply(zoom, key))
     } else {

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -92,7 +92,7 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
 
                 ElevationData(zoom, key, multiPolygon) match {
                   case Some(tile) =>
-                    val floodTile = FloodTile(tile, multiPolygon, args.minElevation, args.floodLevel)
+                    val floodTile = FloodTile(tile, zoom, key, multiPolygon, args.minElevation, args.floodLevel)
 
                     // Paint the tile
                     val justBlueRamp = ColorRamp.createWithRGBColors(0x0000FF).setAlpha(127)

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -4,19 +4,15 @@ import geotrellis.proj4._
 import geotrellis.vector._
 import geotrellis.vector.io.json._
 import geotrellis.vector.reproject._
-import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.spark._
 
 import akka.actor._
 
 import spray.routing._
-import spray.http.MediaTypes
 import spray.http.HttpHeaders._
 import spray.http.HttpMethods._
 import spray.http.{ AllOrigins, MediaTypes }
-import spray.http.{ HttpMethods, HttpMethod, HttpResponse, AllOrigins }
-import spray.httpx.SprayJsonSupport._
 import spray.json._
 
 import org.apache.spark._

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
@@ -3,10 +3,7 @@ package com.azavea.usaceflood.server
 import geotrellis.vector._
 import geotrellis.raster._
 import geotrellis.raster.op.local._
-import geotrellis.raster.render._
 import geotrellis.spark._
-
-import scala.collection.mutable
 
 import org.apache.spark._
 
@@ -35,4 +32,3 @@ object FloodTile {
     }
   }
 }
-

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
@@ -2,6 +2,7 @@ package com.azavea.usaceflood.server
 
 import geotrellis.vector._
 import geotrellis.raster._
+import geotrellis.raster.op.local._
 import geotrellis.raster.render._
 import geotrellis.spark._
 
@@ -13,19 +14,25 @@ object FloodTile {
   /** Takes a polygon, flood level, zoom level and tile coordinates.
     * Returns a tile with the flood levels of each cell.
     * 
-    * @param       multiPolygon  MultiPolygon in EPSG:4269
+    * @param       zoom          Zoom level used to get extent for clipping
+    * @param       key           Spatial key used to get extent for clipping
+    * @param       multiPolygon  MultiPolygon in EPSG:4269 to clip output to
     * @param       minElevation  Minimum elevation under this polygon
     * @param       floodLevel    Flood level to use for determining cell flooding
     * 
     * @return      Tile with flood level of each flooded cell, NoData if the cell is not flooded.
     */
-  def apply(tile: Tile, multiPolygon: MultiPolygon, minElevation: Double, floodLevel: Double)(implicit sc: SparkContext): Tile =
-    tile.mapDouble { z =>
-      if(isData(z) && z - minElevation < floodLevel) {
+  def apply(tile: Tile, zoom: Int, key: SpatialKey, multiPolygon: MultiPolygon, minElevation: Double, floodLevel: Double)(implicit sc: SparkContext): Tile = {
+    val extent = ElevationData.getExtent(zoom, key)
+    val maskedTile = tile.mask(extent, multiPolygon)
+
+    maskedTile.mapDouble { z =>
+      if (isData(z) && z - minElevation < floodLevel) {
         z - minElevation
       } else {
         Double.NaN
       }
     }
+  }
 }
 


### PR DESCRIPTION
## Overview

Previously we were not clipping the flood level results to the polygon, thus rendering a lot of extraneous and confusing output. This ensures that the output will be restricted to the specified multipolygon.

### Technical Explanation

We need the extent to perform a `mask` which is a raster local operation. This extent was currently limited to the `ElevationData`, but since we need it in `FloodTile` as well we spin it into its own method and call it from `FloodTile`.

## Testing Instructions

General testing overview is the same as #10. Save this file as `multiPolygon.json`: http://dpaste.com/3V9PJCA

On `develop` from within the Vagrant VM, the following tile should be rendered:

```http
$ vagrant ssh -c 'http -do before.png :8090/flood-tiles/13/1913/3063.png Accept:image/png multiPolygon:=@multiPolygon.json minElevation:=293.0 floodLevel:=10'
HTTP/1.1 200 OK
Content-Length: 3108
Content-Type: image/png
Date: Fri, 08 Jan 2016 21:15:48 GMT
Server: spray-can/1.3.3

Downloading 3.04 kB to "before.png"
Done. 3.04 kB in 0.00044s (6.75 MB/s)
```

![before](https://cloud.githubusercontent.com/assets/1430060/12209817/941b70ec-b623-11e5-8ba7-72a8f1523a5d.png)

On this branch, the following clipped-to-the-polygon tile should be rendered:

```http
$ vagrant ssh -c 'http -do after.png :8090/flood-tiles/13/1913/3063.png Accept:image/png multiPolygon:=@multiPolygon.json minElevation:=293.0 floodLevel:=10'
HTTP/1.1 200 OK
Content-Length: 2999
Content-Type: image/png
Date: Fri, 08 Jan 2016 21:14:59 GMT
Server: spray-can/1.3.3

Downloading 2.93 kB to "after.png"
Done. 2.93 kB in 0.00034s (8.47 MB/s)
```

![after](https://cloud.githubusercontent.com/assets/1430060/12209840/bc52e20c-b623-11e5-8921-a414f06101be.png)

## Demo

![image](https://cloud.githubusercontent.com/assets/1430060/12268349/68aa00b4-b91a-11e5-8bdc-29cc9e06bab4.png)

Connects #12 