### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: required
+
+language: scala
+
+services:
+- docker
+
+cache:
+  directories:
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt/boot/
+
+script:
+- mkdir -p ${HOME}/.sbt
+- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" compile
+
+before_deploy:
+- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" assembly
+- sudo chown ${USER} summary/target/scala-2.10/usaceflood-server-assembly-${TRAVIS_TAG}.jar
+
+deploy:
+  provider: releases
+  api_key:
+    secure: V0yjW7wr+ke9pdVbwvgghBHgCM1/dobiOcmopdTT6aXG8oZew7GB60dx9GbUCYpCqM534/O2r0vDSm1D1z83ctAz6n9L1HZiHbOC9u1kjcYOzjdl1I/5qXteRSZ6a0PR8gvxSVjEwCbDqIKi9nggCcrUB8ZEfmo6GSBouuNUpVxfL4V+3oX/FswpexL73Z0HKNSyS44lOg2u8zhVlUpxZkMDpWw+tLbYw7n/dtGfkQ/bA2nADTXv2UZalwlhZXOGMf0up67INmseAaQcnLwNZqOacR9QrYmdoQUS97yug2lt7HHmzHHqhhboGnUy5YdxY0eUwWaflUXkH9E3an1UfOl61qbWYNEO0xxKG1dK78/DspcFYt6TfKtNKyYHbrw/VaZeiMYR8qPC8iyhEoQVaRxZ7zIL0A5Cj0hiRreppuWzU9xGGj4HgFxHEJfCQSeORVDS8c385MjbFjzvOvTPs7mdimvama79x4iWB+DruMygVBIUu/K0rJIMslmjkD5VJGBL9el8HyaQQN1w+tR0HCCEzNAtDV+tHOGoFuoQpFzfyZBFB2Iax5cFSkpC5BsdPESCHwrLsHCoBFoJTYS/QnXaq9F1HHzRM8FJBNzsw2dIprG8+mqFy7Amy3X1uq3XsEu1WFKmp0WLCfR9vw8FMRFAy3sg1hikiy2g0zUwFvw=
+  file:
+    - server/target/scala-2.10/usaceflood-server-assembly-${TRAVIS_TAG}.jar
+  skip_cleanup: true
+  on:
+    repo: azavea/usace-flood-geoprocessing
+    tags: true

--- a/README.md
+++ b/README.md
@@ -204,4 +204,22 @@ The server can be stopped with <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
 ### Deployment
 
-After the JAR is built, it should be placed under `/opt/geoprocessing/` inside the VM. Deployments to GitHub Releases are handled via [Travis-CI](https://travis-ci.org/azavea/usace-flood-geoprocessing).
+To test locally, after the JAR is built, it should be placed under `/opt/geoprocessing/` inside the VM.
+
+Deployments to GitHub Releases are handled via [Travis-CI](https://travis-ci.org/azavea/usace-flood-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release:
+
+``` bash
+$ git flow release start 0.1.0
+$ vim CHANGELOG.md
+$ git commit -m "0.1.0"
+$ git flow release publish 0.1.0
+$ git flow release finish 0.1.0
+```
+
+You should now check the `develop` and `master` branches on Github to make sure that they look correct.  In particular, they should both contain the changes that you made to `CHANGELOG.md`.  If they do not, then the following two steps may also be required:
+```bash
+$ git push origin develop:develop
+$ git push origin master:master
+```
+
+To actually kick off the deployment, ensure that the newly created Git tags are pushed remotely with `git push --tags`.

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  val floodmodel = "0.1.0" + either("FLOODMODEL_VERSION_SUFFIX", "-SNAPSHOT")
+  val floodmodel = either("TRAVIS_TAG", "SNAPSHOT")
 
   val scala = "2.10.6"
   val geotrellis = "0.10.0-561030e"


### PR DESCRIPTION
This enables Travis to build and deploy jar files using the instructions added to the README. You can still build the jar file locally using `./sbt "project server" assembly` resulting in `server/target/scala-2.10/usaceflood-server-assembly-SNAPSHOT.jar`. 