### PR TITLE
Visualize Depth

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -76,36 +76,34 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
     }
 
   def floodTilesRoute =
-    rejectEmptyResponse {
-      pathPrefix(IntNumber / IntNumber / IntNumber) { (zoom, x, y) =>
-        entity(as[floodTilesArgs]) { (args) =>
-          respondWithMediaType(MediaTypes.`image/png`) {
-            complete {
-              future {
+    pathPrefix(IntNumber / IntNumber / IntNumber) { (zoom, x, y) =>
+      entity(as[floodTilesArgs]) { (args) =>
+        respondWithMediaType(MediaTypes.`image/png`) {
+          complete {
+            future {
 
-                val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, WebMercator)
-                val key = SpatialKey(x, y)
+              val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, WebMercator)
+              val key = SpatialKey(x, y)
 
-                ElevationData(zoom, key, multiPolygon) match {
-                  case Some(tile) =>
-                    val floodTile = FloodTile(tile, zoom, key, multiPolygon, args.minElevation, args.floodLevel)
+              ElevationData(zoom, key, multiPolygon) match {
+                case Some(tile) =>
+                  val floodTile = FloodTile(tile, zoom, key, multiPolygon, args.minElevation, args.floodLevel)
 
-                    // Paint the tile
-                    val breaks = ColorBreaks.fromStringDouble(
-                      """0.0000:c2dae8b3;
-                        |0.3048:a0bcd9b3;
-                        |0.6096:7c9fc7b3;
-                        |0.9144:4b81b3b3;
-                        |1.2192:2c6ca0b3;
-                        |1.5240:3d5485b3;
-                        |3.0480:414273b3;
-                        |4.5720:393264b3;
-                        |1000.0:393264b3;""".stripMargin).get
-                    floodTile.renderPng(breaks).bytes
+                  // Paint the tile
+                  val breaks = ColorBreaks.fromStringDouble(
+                    """0.0000:c2dae8b3;
+                      |0.3048:a0bcd9b3;
+                      |0.6096:7c9fc7b3;
+                      |0.9144:4b81b3b3;
+                      |1.2192:2c6ca0b3;
+                      |1.5240:3d5485b3;
+                      |3.0480:414273b3;
+                      |4.5720:393264b3;
+                      |1000.0:393264b3;""".stripMargin).get
+                  floodTile.renderPng(breaks).bytes
 
-                  case None =>
-                    Array[Byte]()
-                }
+                case None =>
+                  Array[Byte]()
               }
             }
           }

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -91,8 +91,17 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
                     val floodTile = FloodTile(tile, zoom, key, multiPolygon, args.minElevation, args.floodLevel)
 
                     // Paint the tile
-                    val justBlueRamp = ColorRamp.createWithRGBColors(0x0000FF).setAlpha(127)
-                    floodTile.renderPng(justBlueRamp).bytes
+                    val breaks = ColorBreaks.fromStringDouble(
+                      """0.0000:c2dae8b3;
+                        |0.3048:a0bcd9b3;
+                        |0.6096:7c9fc7b3;
+                        |0.9144:4b81b3b3;
+                        |1.2192:2c6ca0b3;
+                        |1.5240:3d5485b3;
+                        |3.0480:414273b3;
+                        |4.5720:393264b3;
+                        |1000.0:393264b3;""".stripMargin).get
+                    floodTile.renderPng(breaks).bytes
 
                   case None =>
                     Array[Byte]()

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
@@ -25,7 +25,7 @@ object FloodTile {
 
     maskedTile.mapDouble { z =>
       if (isData(z) && z - minElevation < floodLevel) {
-        z - minElevation
+        floodLevel - (z - minElevation)
       } else {
         Double.NaN
       }


### PR DESCRIPTION
## Overview

We move to a rendering which shows how much a cell will be flooded at a given flood level, instead of showing at what flood level will the cell flood. This will be the difference between the flood level, and the relative elevation of the cell (which is its elevation minus the minimum elevation).

Also, we add color breaks specified by the client. We repeat the final value to a very high maximum (virtually infinite flooding) to ensure that the last color persists even in values beyond that of the last break 15'. Without it, GeoTrellis defaults to the value of the first break, which is very light, and misrepresentative of the true amount of flooding in the cell.

These are the color breaks used:
- ![color](http://placehold.it/14/c2dae8) #c2dae8 for 0 - 1'
- ![color](http://placehold.it/14/a0bcd9) #a0bcd9 for 1 - 2'
- ![color](http://placehold.it/14/7c9fc7) #7c9fc7 for 2 - 3'
- ![color](http://placehold.it/14/4b81b3) #4b81b3 for 3 - 4'
- ![color](http://placehold.it/14/2c6ca0) #2c6ca0 for 4 - 5'
- ![color](http://placehold.it/14/3d5485) #3d5485 for 5 - 10'
- ![color](http://placehold.it/14/414273) #414273 for 10 - 15'
- ![color](http://placehold.it/14/393264) #393264 for 15' and up

Here are flood levels in a certain polygon in east Omaha at 5', 10', 15', 20', and 25':

![eastomaha-flood-level-breaks](https://cloud.githubusercontent.com/assets/1430060/12305468/f5866b24-ba02-11e5-872a-35a9f67521ea.png)

And here is a gif showing the flooding from 1' to 25':

![eastomaha-flood-level-breaks](https://cloud.githubusercontent.com/assets/1430060/12305608/ac2230b6-ba03-11e5-974e-6bf3231c8d57.gif)

**Note** The colors will look lighter in the app than they do in the above demo images, which have no transparency. In the app, we set them to 30% transparent so once can still see the underlying areas.

Also, we switch from returning 404s to 200s for valid empty tiles. This reduces the amount of error messages seen in the browser.
## Testing Instructions

Build the JAR

```
./sbt "project server" assembly
```

Copy the JAR into the vagrant VM under `/opt/geoprocessing/` and restart the geoprocessing service

```
sudo service usace-geop restart
```

Then try it out in the browser. Ensure that you can see differing colors at different flood levels. Also ensure you see no 404s in the console.

![image](https://cloud.githubusercontent.com/assets/1430060/12306053/c67409b0-ba05-11e5-9f62-2b9f5e33ff5a.png)

Connects #14 
Connects #15 
