### PR TITLE
Return blank PNG instead of nothing

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -4,6 +4,7 @@ import geotrellis.proj4._
 import geotrellis.vector._
 import geotrellis.vector.io.json._
 import geotrellis.vector.reproject._
+import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.spark._
 
@@ -103,7 +104,7 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
                   floodTile.renderPng(breaks).bytes
 
                 case None =>
-                  Array[Byte]()
+                  ArrayTile.empty(TypeByte, 256, 256).renderPng().bytes
               }
             }
           }


### PR DESCRIPTION
## Overview

In certain versions of Leaflet, 0 byte 200s are rendered as missing images. To prevent that, we switch returning completely transparent valid images instead.
## Testing Instructions

Deploy the new JAR, open the network tab in the browser and observe the responses for areas of the map where you should see "nothing". The response should be an empty PNG 256⨉256 pixels in size, instead of a 0 byte "missing image".
## Demo

![image](https://cloud.githubusercontent.com/assets/1430060/12332033/4d952384-baba-11e5-9a78-2060e894f7ac.png)

Connects https://github.com/azavea/usace-flood-model/pull/100
