### PR TITLE
Return max as well as min elevation

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -42,19 +42,20 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
 
   def root =
     path("ping") { complete { "OK" } } ~
-    pathPrefix("min-elevation") { minElevationRoute } ~
+    pathPrefix("elevation") { elevationRoute } ~
     pathPrefix("flood-percentages") { floodPercentagesRoute } ~
     pathPrefix("flood-tiles") { floodTilesRoute }
 
-  def minElevationRoute =
+  def elevationRoute =
     cors {
       import spray.json.DefaultJsonProtocol._
 
-      entity(as[minElevationArgs]) { (args) =>
+      entity(as[elevationArgs]) { (args) =>
         complete {
           future {
             val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, nativeCRS)
             JsObject(
+              "maxElevation" -> JsNumber(MaxElevation(multiPolygon)),
               "minElevation" -> JsNumber(MinElevation(multiPolygon))
             )
           }

--- a/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
@@ -3,14 +3,14 @@ package com.azavea.usaceflood.server
 import spray.httpx.SprayJsonSupport
 import spray.json._
 
-case class minElevationArgs (multiPolygon: JsObject)
+case class elevationArgs (multiPolygon: JsObject)
 case class floodPercentagesArgs (multiPolygon: JsObject, minElevation: Double, floodLevels: Array[Double])
 case class floodTilesArgs (multiPolygon: JsObject, minElevation: Double, floodLevel: Double)
 
 object JsonProtocol extends SprayJsonSupport {
   import DefaultJsonProtocol._
 
-  implicit val minElevationFormat = jsonFormat1(minElevationArgs)
+  implicit val elevationFormat = jsonFormat1(elevationArgs)
   implicit val floodPercentagesFormat = jsonFormat3(floodPercentagesArgs)
   implicit val floodTilesFormat = jsonFormat3(floodTilesArgs)
 }

--- a/server/src/main/scala/com/azavea/usaceflood/server/MaxElevation.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/MaxElevation.scala
@@ -1,0 +1,18 @@
+package com.azavea.usaceflood.server
+
+import geotrellis.vector._
+import geotrellis.spark.op.zonal.summary._
+
+import org.apache.spark._
+
+object MaxElevation {
+  /** Takes a polygon and returns the elevation of the highest cell
+    * within the polygon.
+    *
+    * @param       multiPolygon  MultiPolygon in EPSG:4269
+    *
+    * @return      Elevation in meters
+    */
+  def apply(multiPolygon: MultiPolygon)(implicit sc: SparkContext): Double =
+    ElevationData(multiPolygon).zonalMax(multiPolygon)
+}


### PR DESCRIPTION
## Overview

 * Change route from `/min-elevation` → `/elevation`
 * Output now includes `maxElevation` as well as `minElevation`

We add it to an existing route instead of creating a new one to minimize network traffic to get a simple float value.

## Demo

```http
$ http :8090/elevation multiPolygon:=@multiPolygon.json
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Accept-Language, Host, Referer, User-Agent, Access-Control-Request-Method, Access-Control-Request-Headers
Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE
Access-Control-Allow-Origin: *
Content-Length: 52
Content-Type: application/json; charset=UTF-8
Date: Fri, 15 Jan 2016 16:58:53 GMT
Server: spray-can/1.3.3

{
    "maxElevation": 314.0, 
    "minElevation": 293.0
}
```

Where [multiPolygon.json](https://github.com/azavea/usace-flood-geoprocessing/files/92227/multiPolygon.json.txt) is attached.

Connects #19 