### PR TITLE
Dynamic Color Breaks

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodModelServiceActor.scala
@@ -42,19 +42,20 @@ class FloodModelServiceActor(sc: SparkContext) extends Actor with HttpService {
 
   def root =
     path("ping") { complete { "OK" } } ~
-    pathPrefix("min-elevation") { minElevationRoute } ~
+    pathPrefix("elevation") { elevationRoute } ~
     pathPrefix("flood-percentages") { floodPercentagesRoute } ~
     pathPrefix("flood-tiles") { floodTilesRoute }
 
-  def minElevationRoute =
+  def elevationRoute =
     cors {
       import spray.json.DefaultJsonProtocol._
 
-      entity(as[minElevationArgs]) { (args) =>
+      entity(as[elevationArgs]) { (args) =>
         complete {
           future {
             val multiPolygon = args.multiPolygon.toString().parseGeoJson[MultiPolygon].reproject(LatLng, nativeCRS)
             JsObject(
+              "maxElevation" -> JsNumber(MaxElevation(multiPolygon)),
               "minElevation" -> JsNumber(MinElevation(multiPolygon))
             )
           }

--- a/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
@@ -5,12 +5,12 @@ import spray.json._
 
 case class elevationArgs (multiPolygon: JsObject)
 case class floodPercentagesArgs (multiPolygon: JsObject, minElevation: Double, floodLevels: Array[Double])
-case class floodTilesArgs (multiPolygon: JsObject, minElevation: Double, floodLevel: Double)
+case class floodTilesArgs (multiPolygon: JsObject, minElevation: Double, maxElevation: Double, floodLevel: Double)
 
 object JsonProtocol extends SprayJsonSupport {
   import DefaultJsonProtocol._
 
   implicit val elevationFormat = jsonFormat1(elevationArgs)
   implicit val floodPercentagesFormat = jsonFormat3(floodPercentagesArgs)
-  implicit val floodTilesFormat = jsonFormat3(floodTilesArgs)
+  implicit val floodTilesFormat = jsonFormat4(floodTilesArgs)
 }

--- a/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
@@ -3,14 +3,14 @@ package com.azavea.usaceflood.server
 import spray.httpx.SprayJsonSupport
 import spray.json._
 
-case class minElevationArgs (multiPolygon: JsObject)
+case class elevationArgs (multiPolygon: JsObject)
 case class floodPercentagesArgs (multiPolygon: JsObject, minElevation: Double, floodLevels: Array[Double])
 case class floodTilesArgs (multiPolygon: JsObject, minElevation: Double, floodLevel: Double)
 
 object JsonProtocol extends SprayJsonSupport {
   import DefaultJsonProtocol._
 
-  implicit val minElevationFormat = jsonFormat1(minElevationArgs)
+  implicit val elevationFormat = jsonFormat1(elevationArgs)
   implicit val floodPercentagesFormat = jsonFormat3(floodPercentagesArgs)
   implicit val floodTilesFormat = jsonFormat3(floodTilesArgs)
 }

--- a/server/src/main/scala/com/azavea/usaceflood/server/MaxElevation.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/MaxElevation.scala
@@ -1,0 +1,18 @@
+package com.azavea.usaceflood.server
+
+import geotrellis.vector._
+import geotrellis.spark.op.zonal.summary._
+
+import org.apache.spark._
+
+object MaxElevation {
+  /** Takes a polygon and returns the elevation of the highest cell
+    * within the polygon.
+    *
+    * @param       multiPolygon  MultiPolygon in EPSG:4269
+    *
+    * @return      Elevation in meters
+    */
+  def apply(multiPolygon: MultiPolygon)(implicit sc: SparkContext): Double =
+    ElevationData(multiPolygon).zonalMax(multiPolygon)
+}


### PR DESCRIPTION
## Overview

 * Change route from `/min-elevation` → `/elevation`
 * Output now includes `maxElevation` as well as `minElevation`

We add it to an existing route instead of creating a new one to minimize network traffic to get a simple float value.

 * The `/flood-tiles` route now takes an additional `maxElevation` parameter
 * This parameter is used to calculate the total range, which is broken into 20 equal divisions and paired with 20 colors ranging from the lightest to darkest as defined in #18.

## Demo

```http
$ http :8090/elevation multiPolygon:=@eastOmaha.json
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Accept-Language, Host, Referer, User-Agent, Access-Control-Request-Method, Access-Control-Request-Headers
Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE
Access-Control-Allow-Origin: *
Content-Length: 52
Content-Type: application/json; charset=UTF-8
Date: Fri, 15 Jan 2016 20:26:10 GMT
Server: spray-can/1.3.3

{
    "maxElevation": 314.0, 
    "minElevation": 293.0
}
```

where [eastOmaha.json](https://github.com/azavea/usace-flood-geoprocessing/files/92509/eastOmaha.json.txt) is attached.

For the dynamic color breaks, this east Omaha test polygon has a range of 314 - 293 = 21 m, or ~69'. Here is the polygon at 4', 20', 36', 52', and 68':

![eastomaha-dynamic-breaks-full-range](https://cloud.githubusercontent.com/assets/1430060/12365148/0079a2a4-bba1-11e5-8726-4f6ae208d638.png)

Here's a gif of the full flooding from 0' to 68' over 20 breaks:

![eastomaha-dynamic-breaks-full-range](https://cloud.githubusercontent.com/assets/1430060/12365160/0f386b2c-bba1-11e5-9eea-cb7e3d7e74cf.gif)

_Note:_ These images are darker than actual renderings because they have no transparency (for presentation purposes).

To generate one of these tiles yourself, do:

```http
$ http -do test.png :8090/flood-tiles/12/956/1531.png Accept:image/png multiPolygon:=@eastOmaha.json maxElevation:=314 minElevation:=293 floodLevel:=10
HTTP/1.1 200 OK
Content-Length: 4446
Content-Type: image/png
Date: Fri, 15 Jan 2016 21:09:47 GMT
Server: spray-can/1.3.3

Downloading 4.34 kB to "test.png"
Done. 4.34 kB in 0.00040s (10.68 MB/s)
```

which should produce:

![test](https://cloud.githubusercontent.com/assets/1430060/12365387/7ec69ac6-bba2-11e5-8463-1724b24e739b.png)

### Warning

This PR will break the app because the back-end endpoints have changed. The middleware is being updated as part of https://github.com/azavea/usace-flood-model/issues/99

Supersedes #22 
Connects #21 
Connects #19 