### PR TITLE
Get TRAVIS_TAG into Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ cache:
 
 script:
 - mkdir -p ${HOME}/.sbt
-- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" compile
+- export TRAVIS_TAG=0.2.0
+- docker run -e "TRAVIS_TAG=$TRAVIS_TAG" -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" assembly
+- sudo chown ${USER} server/target/scala-2.10/usaceflood-server-assembly-${TRAVIS_TAG}.jar
+#- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" compile
 
 before_deploy:
 - docker run -e "TRAVIS_TAG=$TRAVIS_TAG" -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" assembly

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" compile
 
 before_deploy:
-- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" assembly
+- docker run -e "TRAVIS_TAG=$TRAVIS_TAG" -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" assembly
 - sudo chown ${USER} server/target/scala-2.10/usaceflood-server-assembly-${TRAVIS_TAG}.jar
 
 deploy:


### PR DESCRIPTION
This is to fix a problem where sbt didn't have the `TRAVIS_TAG` environment variable because it wasn't being explicitly passed into the container. I'm not sure how the other geoprocessing repos are able to do this without explicitly passing in that variable. 

It would be nice if we could test Travis deployment configurations without having to first merge into develop and then create a release. \cc @hectcastro 