### PR TITLE
Get version from Version.scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ cache:
 
 script:
 - mkdir -p ${HOME}/.sbt
-- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" compile
+- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/spark:latest ./sbt "project server" compile
 
 before_deploy:
-- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt "project server" assembly
-- sudo chown ${USER} server/target/scala-2.10/usaceflood-server-assembly-${TRAVIS_TAG}.jar
+- docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-flood-geoprocessing -w /usace-flood-geoprocessing quay.io/azavea/spark:latest ./sbt "project server" assembly
+- sudo chown ${USER} server/target/scala-2.10/usaceflood-server-assembly-${TRAVIS_TAG}-SNAPSHOT.jar
 
 deploy:
   provider: releases

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build the ingest JAR, execute the following:
 $ ./sbt "project ingest" assembly
 ```
 
-which should result in `ingest/target/scala-2.10/usaceflood-ingest-assembly-SNAPSHOT.jar`.
+which should result in `ingest/target/scala-2.10/usaceflood-ingest-assembly-<version>-SNAPSHOT.jar`.
 
 ### Usage
 
@@ -30,7 +30,7 @@ We ingest the two tile sets one by one. For the purposes of calculating area, we
 ```bash
 #!/bin/bash
 
-JAR=ingest/target/scala-2.10/usaceflood-ingest-assembly-SNAPSHOT.jar
+JAR=ingest/target/scala-2.10/usaceflood-ingest-assembly-<version>-SNAPSHOT.jar
 
 SOURCE=~/data/tiles-4269
 DEST=~/data/catalog
@@ -48,7 +48,7 @@ For the purposes of rendering tiles, we want the WebMercator projection and we w
 ```bash
 #!/bin/bash
 
-JAR=ingest/target/scala-2.10/usaceflood-ingest-assembly-SNAPSHOT.jar
+JAR=ingest/target/scala-2.10/usaceflood-ingest-assembly-<version>-SNAPSHOT.jar
 
 SOURCE=~/data/tiles-webm
 DEST=~/data/catalog
@@ -172,7 +172,7 @@ To build the server JAR, execute the following:
 $ ./sbt "project server" assembly
 ```
 
-which should result in `server/target/scala-2.10/usaceflood-server-assembly-SNAPSHOT.jar`.
+which should result in `server/target/scala-2.10/usaceflood-server-assembly-<version>-SNAPSHOT.jar`.
 
 ### Usage
 
@@ -190,7 +190,7 @@ For running the server locally, assuming the catalog is available in `~/data/cat
 
 ```bash
 $ export RDD_CATALOG_PATH=~/data/catalog
-$ spark-submit server/target/scala-2.10/usaceflood-server-assembly-SNAPSHOT.jar
+$ spark-submit server/target/scala-2.10/usaceflood-server-assembly-<version>-SNAPSHOT.jar
 ```
 
 As Spark loads the JAR it will output a number of messages. Once the following are shown, the server is ready to accept requests:
@@ -206,11 +206,12 @@ The server can be stopped with <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
 To test locally, after the JAR is built, it should be placed under `/opt/geoprocessing/` inside the VM.
 
-Deployments to GitHub Releases are handled via [Travis-CI](https://travis-ci.org/azavea/usace-flood-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release:
+Deployments to GitHub Releases are handled via [Travis-CI](https://travis-ci.org/azavea/usace-flood-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release. The `version` variable should be updated in `project/Version.scala.`
 
 ``` bash
 $ git flow release start 0.1.0
 $ vim CHANGELOG.md
+$ vim project/Version.scala
 $ git commit -m "0.1.0"
 $ git flow release publish 0.1.0
 $ git flow release finish 0.1.0

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,8 @@ object Version {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  val floodmodel = either("TRAVIS_TAG", "SNAPSHOT")
+  val version = "0.1.3"
+  val floodmodel = version + either("FLOODMODEL_VERSION_SUFFIX", "-SNAPSHOT")
 
   val scala = "2.10.6"
   val geotrellis = "0.10.0-561030e"


### PR DESCRIPTION
Previously, I was trying to get SBT to get the version number from the `TRAVIS_TAG` environment variable, but it should actually get it from Version.scala.

See #26 for discussion