### PR TITLE
Flood Value Endpoint

### DIFF
--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodPointValue.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodPointValue.scala
@@ -1,0 +1,32 @@
+package com.azavea.usaceflood.server
+
+import geotrellis.vector._
+import geotrellis.raster._
+import geotrellis.spark._
+
+import org.apache.spark._
+
+object FloodPointValue {
+  /**
+    * Takes a polygon, flood level, zoom level and tile coordinates, and a point.
+    * Returns the flood amount at that point.
+    *
+    * @param       tile          The tile to get data from
+    * @param       extent        Extent to restrict search to
+    * @param       point         Point in EPSG:4269 to get output for
+    * @param       minElevation  Minimum elevation under this polygon
+    * @param       floodLevel    Flood level to use for determining cell flooding
+    *
+    * @return      Flood level at that point
+    */
+  def apply(tile: Tile, extent: Extent, point: Point, minElevation: Double, floodLevel: Double)(implicit sc: SparkContext): Double = {
+    val (col, row) = RasterExtent(extent, tile.cols, tile.rows).mapToGrid(point.x, point.y)
+    val z = tile.getDouble(col, row)
+
+    if (isData(z) && z - minElevation < floodLevel) {
+      floodLevel - (z - minElevation)
+    } else {
+      Double.NaN
+    }
+  }
+}

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodPointValue.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodPointValue.scala
@@ -21,12 +21,24 @@ object FloodPointValue {
     */
   def apply(tile: Tile, extent: Extent, point: Point, minElevation: Double, floodLevel: Double)(implicit sc: SparkContext): Double = {
     val (col, row) = RasterExtent(extent, tile.cols, tile.rows).mapToGrid(point.x, point.y)
-    val z = tile.getDouble(col, row)
+    val elevation = tile.getDouble(col, row)
 
-    if (isData(z) && z - minElevation < floodLevel) {
-      floodLevel - (z - minElevation)
+    getFlooding(elevation, minElevation, floodLevel)
+  }
+
+  /**
+    * Given the elevation value at a point, and a minElevation and floodLevel,
+    * returns the flood value at that point.
+    *
+    * @param       elevation    Elevation of this point
+    * @param       minElevation Minimum elevation of the polygon in which this point belongs
+    * @param       floodLevel   Flood level to use for determining cell flooding
+    * @return
+    */
+  def getFlooding(elevation: Double, minElevation: Double, floodLevel: Double): Double =
+    if (isData(elevation) && elevation - minElevation < floodLevel) {
+      floodLevel - (elevation - minElevation)
     } else {
       Double.NaN
     }
-  }
 }

--- a/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/FloodTile.scala
@@ -23,12 +23,6 @@ object FloodTile {
     val extent = ElevationData.getExtent(zoom, key)
     val maskedTile = tile.mask(extent, multiPolygon)
 
-    maskedTile.mapDouble { z =>
-      if (isData(z) && z - minElevation < floodLevel) {
-        floodLevel - (z - minElevation)
-      } else {
-        Double.NaN
-      }
-    }
+    maskedTile.mapDouble { elevation => FloodPointValue.getFlooding(elevation, minElevation, floodLevel) }
   }
 }

--- a/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
+++ b/server/src/main/scala/com/azavea/usaceflood/server/JsonProtocol.scala
@@ -6,6 +6,7 @@ import spray.json._
 case class elevationArgs (multiPolygon: JsObject)
 case class floodPercentagesArgs (multiPolygon: JsObject, minElevation: Double, floodLevels: Array[Double])
 case class floodTilesArgs (multiPolygon: JsObject, minElevation: Double, maxElevation: Double, floodLevel: Double)
+case class floodValueArgs (lat: Double, lng: Double, minElevation: Double, floodLevel: Double)
 
 object JsonProtocol extends SprayJsonSupport {
   import DefaultJsonProtocol._
@@ -13,4 +14,5 @@ object JsonProtocol extends SprayJsonSupport {
   implicit val elevationFormat = jsonFormat1(elevationArgs)
   implicit val floodPercentagesFormat = jsonFormat3(floodPercentagesArgs)
   implicit val floodTilesFormat = jsonFormat4(floodTilesArgs)
+  implicit val floodValueFormat = jsonFormat4(floodValueArgs)
 }


### PR DESCRIPTION
## Overview

Given a point (`lat` and `lng`) on a tile (`zoom`, `x`, `y`) at a certain `floodLevel` under a certain polygon with lowest point `minElevation`, returns the flood value at that point.

```http
$ http --print HBhb :8090/flood-value/11/481/774 lat:=40.1673306817866 lng:=-95.42518615722656 minElevation:=257 floodLevel:=7
POST /flood-value/11/481/774 HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 90
Content-Type: application/json
Host: localhost:8090
User-Agent: HTTPie/0.9.3

{
    "floodLevel": 7, 
    "lat": 40.1673306817866, 
    "lng": -95.42518615722656, 
    "minElevation": 257
}

HTTP/1.1 200 OK
Content-Length: 37
Content-Type: application/json; charset=UTF-8
Date: Tue, 23 Feb 2016 15:30:18 GMT
Server: spray-can/1.3.3

{
    "floodValue": 0.882293701171875
}
```

## Approach

These values are _approximate_, because we don't process the full resolution RDD, which takes too long (up to 60s per request). Instead we get the value from the clicked point on the tile, which is a pyramided RDD, and is much quicker to access and process.

We also consolidate the logic used to generate the flood tiles and the flood value, so the outputs will always match.

Connects https://github.com/azavea/usace-flood-model/issues/123